### PR TITLE
Added --additional-jars and --additional-files options

### DIFF
--- a/jar2app.py
+++ b/jar2app.py
@@ -38,17 +38,19 @@ is_python2 = sys.version_info[0] == 2
 if is_python2:
     FileExistsError = OSError
 
-# ------------------------------------------------------------------------------
-# Defaults
-# ------------------------------------------------------------------------------
-DEFAULT_VERSION = '1.0.1'
-DEFAULT_BUNDLE_IDENTIFIER_PREFIX = 'com.jar2app.example.'
-DEFAULT_SIGNATURE = '????'
-DEFAULT_EXECUTABLE_NAME = 'JavaAppLauncher'
 
-# ------------------------------------------------------------------------------
+
+#------------------------------------------------------------------------------
+# Defaults
+#------------------------------------------------------------------------------
+DEFAULT_VERSION='1.0.1'
+DEFAULT_BUNDLE_IDENTIFIER_PREFIX='com.jar2app.example.'
+DEFAULT_SIGNATURE='????'
+DEFAULT_EXECUTABLE_NAME='JavaAppLauncher'
+
+#------------------------------------------------------------------------------
 # The info.plist file with placeholders
-# ------------------------------------------------------------------------------
+#------------------------------------------------------------------------------
 info_plist = """<?xml version="1.0" ?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
@@ -117,9 +119,9 @@ retina_support_string = """<key>NSPrincipalClass</key>
     <string>True</string>"""
 
 
-# ------------------------------------------------------------------------------
+#------------------------------------------------------------------------------
 # Create a directory and ignore the "File already exists" error
-# ------------------------------------------------------------------------------
+#------------------------------------------------------------------------------
 def mkdir_ignore_exists(p):
     try:
         os.mkdir(p)
@@ -127,28 +129,25 @@ def mkdir_ignore_exists(p):
     except FileExistsError:
         return False
 
-
-# ------------------------------------------------------------------------------
+#------------------------------------------------------------------------------
 # Make a file executable
-# ------------------------------------------------------------------------------
+#------------------------------------------------------------------------------
 def make_executable(path):
     mode = os.stat(path).st_mode
     mode |= (mode & 0o444) >> 2
     os.chmod(path, mode)
 
-
-# ------------------------------------------------------------------------------
+#------------------------------------------------------------------------------
 # Just strip the extension from a name
-# ------------------------------------------------------------------------------
+#------------------------------------------------------------------------------
 def strip_extension_from_name(name):
     return os.path.splitext(name)[0]
 
-
-# ------------------------------------------------------------------------------
+#------------------------------------------------------------------------------
 # Determine the main class in a JAR file. This basically involves searching
 # through the JAR (it's just a zip file), locating the MANIFEST.MF file,
 # decompressing it and then finding the main-class line.
-# ------------------------------------------------------------------------------
+#------------------------------------------------------------------------------
 def find_jar_mainclass(jar_file):
     f = ZipFile(jar_file, 'r')
     for file in f.infolist():
@@ -160,8 +159,7 @@ def find_jar_mainclass(jar_file):
                 if line.strip().lower().startswith('main-class'):
                     return line.split(':')[1].strip()
 
-
-# ------------------------------------------------------------------------------
+#------------------------------------------------------------------------------
 # Build the main directory structure of the .App. It should look like
 # <appname>.App/
 #              Contents/
@@ -169,9 +167,9 @@ def find_jar_mainclass(jar_file):
 #                       MacOS/
 #                       Resources/
 #                                 en.lproj/
-# ------------------------------------------------------------------------------
+#------------------------------------------------------------------------------
 def build_directory_structure(app_full_path):
-    mkdir_ignore_exists(os.path.dirname(app_full_path))  # Base output directory where the app is placed. Create it.
+    mkdir_ignore_exists(os.path.dirname(app_full_path)) #Base output directory where the app is placed. Create it.
     mkdir_ignore_exists(app_full_path)
     mkdir_ignore_exists(os.path.join(app_full_path, 'Contents'))
     mkdir_ignore_exists(os.path.join(app_full_path, 'Contents', 'Java'))
@@ -180,38 +178,36 @@ def build_directory_structure(app_full_path):
     mkdir_ignore_exists(os.path.join(app_full_path, 'Contents', 'Resources'))
     mkdir_ignore_exists(os.path.join(app_full_path, 'Contents', 'Resources', 'en.lproj'))
 
-
-# ------------------------------------------------------------------------------
+#------------------------------------------------------------------------------
 # Write the plist file in the desired output folder. Note that these arguments
 # are passed directly to the info_plist string, so some of them (jdk,
 # jvm_arguments...) should have a bit of XML.
 #
 # The destination folder is typically <appname>.App/Contents
-# ------------------------------------------------------------------------------
-def create_plist_file(destination_folder, icon, bundle_identifier, bundle_displayname, bundle_name, bundle_version,
-                      short_version_string, copyright_str, main_class_name, jvm_arguments, jvm_options, jdk,
+#------------------------------------------------------------------------------
+def create_plist_file(destination_folder, icon, bundle_identifier, bundle_displayname, bundle_name,bundle_version,
+                      short_version_string,copyright_str, main_class_name, jvm_arguments, jvm_options, jdk,
                       unique_signature, retina_support, executable):
-    filled_info_plist = info_plist.format(icon=icon,
-                                          bundle_identifier=bundle_identifier,
-                                          bundle_displayname=bundle_displayname,
-                                          bundle_name=bundle_name,
-                                          bundle_version=bundle_version,
-                                          short_version_string=short_version_string,
-                                          copyright=copyright_str,
-                                          main_class_name=main_class_name,
-                                          jvm_arguments=jvm_arguments,
-                                          jvm_options=jvm_options,
-                                          jdk=jdk,
-                                          unique_signature=unique_signature,
-                                          retina_support=retina_support,
-                                          executable=executable,
-                                          version=VERSION)
+    filled_info_plist=info_plist.format(icon=icon,
+                                        bundle_identifier=bundle_identifier,
+                                        bundle_displayname=bundle_displayname,
+                                        bundle_name=bundle_name,
+                                        bundle_version=bundle_version,
+                                        short_version_string=short_version_string,
+                                        copyright=copyright_str,
+                                        main_class_name=main_class_name,
+                                        jvm_arguments=jvm_arguments,
+                                        jvm_options=jvm_options,
+                                        jdk=jdk,
+                                        unique_signature=unique_signature,
+                                        retina_support=retina_support,
+                                        executable=executable,
+                                        version=VERSION)
 
     with open(os.path.join(destination_folder, 'Info.plist'), 'w') as f:
         f.write(filled_info_plist)
 
-
-# ------------------------------------------------------------------------------
+#------------------------------------------------------------------------------
 # Convert a sequence of strings, separated by spaces, into a sequence of
 # <string></string> strings.
 # E.g., "a b c" becomes "<string>a</string>b<string></string><string>c</string>
@@ -219,24 +215,23 @@ def create_plist_file(destination_folder, icon, bundle_identifier, bundle_displa
 # This is to be used for the JVMArguments and JVMOptions in the plist.xml file.
 # Also note that there is some whitespace added. This is to comply with the
 # indent of the xml file.
-# ------------------------------------------------------------------------------
+#------------------------------------------------------------------------------
 def string_to_plist_xmlarray_values(s):
     if not s:
         return ''
-    return '        <string>' + '</string>\n        <string>'.join([i.strip() for i in shlex.split(s)]) + '</string>'
+    return  '        <string>' + '</string>\n        <string>'.join( [i.strip() for i in shlex.split(s) ] ) + '</string>'
 
-
-# ------------------------------------------------------------------------------
+#------------------------------------------------------------------------------
 # Check if JDK/JRE is valid. It can be a zip file or it can be a directory.
 # Returns:
 #   * The xml string to use
 #   * The JDK/JRE folder name (not its full path; e.g. for zip files, it strips
 #     the zip extension)
 #   * Whether the JDK/JRE is a file or a directory
-# ------------------------------------------------------------------------------
+#------------------------------------------------------------------------------
 def determine_jdk(jdk):
     if not jdk:
-        return '', '', True
+        return '','',True
     isfile = os.path.isfile(jdk)
     if isfile:
         if not jdk.lower().endswith('.zip'):
@@ -244,10 +239,9 @@ def determine_jdk(jdk):
         jdk = strip_extension_from_name(os.path.basename(jdk))
 
     dir, name = os.path.split(jdk)
-    return '<key>JVMRuntime</key>\n<string>' + name + '</string>', jdk, isfile
+    return '<key>JVMRuntime</key>\n<string>' + name + '</string>',jdk,isfile
 
-
-# ------------------------------------------------------------------------------
+#------------------------------------------------------------------------------
 # Copy a JDK to the bundled .app. The app_full_path should be the root of
 # the app (e.g. Test.app/). JDK should be the path to the JDK/JRE and
 # jdk_isfile comes from determine_jdk and indicates if the this JDK is a zip
@@ -262,7 +256,7 @@ def determine_jdk(jdk):
 #
 # This JDK should be in the format expected by AppBundler (check if the first
 # directory is just a Contents folder)
-# ------------------------------------------------------------------------------
+#------------------------------------------------------------------------------
 def copy_jdk(app_full_path, jdk, jdk_isfile):
     if jdk:
         if jdk_isfile:
@@ -275,7 +269,7 @@ def copy_jdk(app_full_path, jdk, jdk_isfile):
                 os.rmdir(destination_path)
                 shutil.copytree(jdk_dir, destination_path)
             except FileExistsError as e:
-                raise  # FIXME
+                raise # FIXME
             try:
                 base_path = os.path.join(app_full_path, 'Contents', 'PlugIns')
                 dir = os.listdir(base_path)[0]
@@ -284,10 +278,10 @@ def copy_jdk(app_full_path, jdk, jdk_isfile):
                 os.rename(os.path.join(base_path, dir), final_dir)
                 shutil.rmtree(tmpdir)
             except:
-                raise  # FIXME
+                raise #FIXME
         else:
             destination = os.path.join(app_full_path, 'Contents', 'PlugIns', os.path.basename(jdk))
-            shutil.rmtree(destination, ignore_errors=True)  # Delete old folder (if it exists)
+            shutil.rmtree(destination, ignore_errors=True) # Delete old folder (if it exists)
             shutil.copytree(jdk, destination, symlinks=True)
 
 
@@ -301,22 +295,19 @@ def copy_preserve_status(src, dst):
     except OSError:
         shutil.copy(src, dst)
 
-
-# ------------------------------------------------------------------------------
-# Copy all files to the previously created directory. This involves copying
+#------------------------------------------------------------------------------
+# Copy all files to the previously created directory. This involes copying
 # the Localizable.strings file, the JavaAppLauncher executable and, finally,
 # the JDK/JRE and application icon if they were provided
-# ------------------------------------------------------------------------------
+#------------------------------------------------------------------------------
 def copy_base_files(app_full_path, icon, jar_file, jdk, jdk_isfile, executable, executable_file):
     if icon:
-        copy_preserve_status(icon, os.path.join(app_full_path, 'Contents', 'Resources'))
-    copy_preserve_status(os.path.join(os.path.dirname(sys.argv[0]), 'jar2app_basefiles', 'Localizable.strings'),
-                         os.path.join(app_full_path, 'Contents', 'Resources', 'en.lproj', 'Localizable.strings'))
+        copy_preserve_status(icon,os.path.join(app_full_path, 'Contents', 'Resources'))
+    copy_preserve_status(os.path.join(os.path.dirname(sys.argv[0]), 'jar2app_basefiles', 'Localizable.strings'), os.path.join(app_full_path, 'Contents', 'Resources', 'en.lproj', 'Localizable.strings'))
     if executable_file:
         copy_preserve_status(executable_file, os.path.join(app_full_path, 'Contents', 'MacOS', executable))
     else:
-        copy_preserve_status(os.path.join(os.path.dirname(sys.argv[0]), 'jar2app_basefiles', 'JavaAppLauncher'),
-                             os.path.join(app_full_path, 'Contents', 'MacOS', executable))
+        copy_preserve_status(os.path.join(os.path.dirname(sys.argv[0]), 'jar2app_basefiles', 'JavaAppLauncher'), os.path.join(app_full_path, 'Contents', 'MacOS', executable))
     make_executable(os.path.join(app_full_path, 'Contents', 'MacOS', executable))
     copy_preserve_status(jar_file, os.path.join(app_full_path, 'Contents', 'Java', os.path.basename(jar_file)))
     copy_jdk(app_full_path, jdk, jdk_isfile)
@@ -362,7 +353,7 @@ def copy_additional_files_and_libraries(app_full_path, libs_or_files, default_pa
                 copy_preserve_status(lib_or_file, os.path.join(app_full_path, *default_path))
 
 
-# ------------------------------------------------------------------------------
+#------------------------------------------------------------------------------
 # Determine the destination Appname (and full path) taking into account the
 # parameters. Note that:
 # 1. If output is provided and it is a destination file, its name is used as
@@ -373,13 +364,13 @@ def copy_additional_files_and_libraries(app_full_path, libs_or_files, default_pa
 # 4. Prefer the bundle displayname
 # 5. Prefer the jar name (without extension, of course)
 # We also assume that by default the output should go to the current directory.
-# ------------------------------------------------------------------------------
+#------------------------------------------------------------------------------
 def determine_app_name(jar_name, output, bundle_displayname, bundle_name, auto_append_app):
     if output:
-        dir, name = os.path.split(output)
-        if not dir:  # All that was given was a filename
+        dir,name = os.path.split(output)
+        if not dir: #All that was given was a filename
             dir = '.'
-    else:  # Assume default directory
+    else: #Assume default directory
         dir = '.'
         name = ''
 
@@ -389,26 +380,25 @@ def determine_app_name(jar_name, output, bundle_displayname, bundle_name, auto_a
         # 2. the bundle_displayname, if it was provided
         # 3. The jar name
         if bundle_name:
-            return os.path.join(dir, bundle_name + '.app')
+            return os.path.join(dir,bundle_name + '.app')
         elif bundle_displayname:
-            return os.path.join(dir, bundle_displayname + '.app')
+            return os.path.join(dir,bundle_displayname + '.app')
         elif jar_name:
-            return os.path.join(dir, strip_extension_from_name(jar_name) + '.app')
+            return os.path.join(dir,strip_extension_from_name(jar_name) + '.app')
     else:
         # Ensure the name ends with .app, unless we were told not to do so
         if auto_append_app:
             if name.lower().endswith('.app'):
-                return os.path.join(dir, name)
+                return os.path.join(dir,name)
             else:
-                return os.path.join(dir, name + '.app')
+                return os.path.join(dir,name + '.app')
         else:
-            return os.path.join(dir, name)
+            return os.path.join(dir,name)
 
-
-# ------------------------------------------------------------------------------
+#------------------------------------------------------------------------------
 # Print summary info on the fields used, if they are used. Used when the
 # process is done
-# ------------------------------------------------------------------------------
+#------------------------------------------------------------------------------
 def print_final_file_info(icon, bundle_identifier, bundle_displayname, bundle_name, short_version_string,
                           unique_signature, bundle_version, copyright_str, orig_jvm_options, main_class_name,
                           jdk, retina_support, use_screen_menu_bar, working_directory, executable):
@@ -437,13 +427,12 @@ def print_final_file_info(icon, bundle_identifier, bundle_displayname, bundle_na
     print_field_if_not_null('Executable Name (CFBundleExecutable)', executable)
     print_field_if_not_null('JAR Working directory', working_directory)
 
-
-# ------------------------------------------------------------------------------
+#------------------------------------------------------------------------------
 # This is the main application logic. It receives the arguments straight from
 # the user, gives appropriate defaults, builds the directory structure,
 # copies files (packing the JDK/JRE) and creates the plist file. In the end,
 # if all went well, it displays summary info.
-# ------------------------------------------------------------------------------
+#------------------------------------------------------------------------------
 def make_app(jar_file, output='.', icon=None, bundle_identifier=None, bundle_displayname=None, bundle_name=None,
              bundle_version=None, short_version_string=None, copyright_str=None, main_class_name=None,
              jvm_arguments=None, jvm_options=None, jdk=None, unique_signature=None, auto_append_app=True,
@@ -452,12 +441,12 @@ def make_app(jar_file, output='.', icon=None, bundle_identifier=None, bundle_dis
     def default_value(d, default):
         return d if d else default
 
-    orig_jvm_options = jvm_options
+    orig_jvm_options  = jvm_options
     if not jvm_options: jvm_options = ''
-    jar_name = os.path.basename(jar_file)
-    app_full_path = determine_app_name(jar_name, output, bundle_displayname, bundle_name, auto_append_app)
-    app_name = strip_extension_from_name(os.path.basename(app_full_path))
-    icon = default_value(icon, '')
+    jar_name          = os.path.basename(jar_file)
+    app_full_path     = determine_app_name(jar_name, output, bundle_displayname, bundle_name, auto_append_app)
+    app_name          = strip_extension_from_name(os.path.basename(app_full_path))
+    icon              = default_value(icon, '')
     bundle_identifier = default_value(bundle_identifier, DEFAULT_BUNDLE_IDENTIFIER_PREFIX + app_name)
 
     if jdk:
@@ -481,7 +470,7 @@ def make_app(jar_file, output='.', icon=None, bundle_identifier=None, bundle_dis
         else:
             bundle_displayname = app_name
 
-    # Set the app name in the macOS menu bar (About and Quit menu items)
+	# Set the app name in the macOS menu bar (About and Quit menu items)
     jvm_options += ' -Xdock:name="%s"' % bundle_displayname
 
     # When we get here, we always have a displayname. So if there's no bundlename, go with that. It may itself have
@@ -489,16 +478,16 @@ def make_app(jar_file, output='.', icon=None, bundle_identifier=None, bundle_dis
     bundle_name = default_value(bundle_name, bundle_displayname)
 
     if not bundle_version:
-        bundle_version = short_version_string if short_version_string else DEFAULT_VERSION
+            bundle_version = short_version_string if short_version_string else DEFAULT_VERSION
 
     # When we get here, we always have bundle_version, even if it is the default
-    short_version_string = default_value(short_version_string, bundle_version)
-    copyright_str = default_value(copyright_str, '')
-    main_class_name = default_value(main_class_name, find_jar_mainclass(jar_file))
-    unique_signature = default_value(unique_signature, '????')
-    jvm_arguments = string_to_plist_xmlarray_values(jvm_arguments)
-    jvm_options = string_to_plist_xmlarray_values(jvm_options)
-    jdk_xml, jdk_name, jdk_isfile = determine_jdk(jdk)
+    short_version_string        = default_value(short_version_string, bundle_version)
+    copyright_str               = default_value(copyright_str, '')
+    main_class_name             = default_value(main_class_name, find_jar_mainclass(jar_file))
+    unique_signature            = default_value(unique_signature, '????')
+    jvm_arguments               = string_to_plist_xmlarray_values(jvm_arguments)
+    jvm_options                 = string_to_plist_xmlarray_values(jvm_options)
+    jdk_xml,jdk_name,jdk_isfile = determine_jdk(jdk)
 
     if retina_screen:
         retina_screen = retina_support_string
@@ -509,7 +498,7 @@ def make_app(jar_file, output='.', icon=None, bundle_identifier=None, bundle_dis
 
     build_directory_structure(app_full_path)
     create_plist_file(os.path.join(app_full_path, 'Contents'), os.path.basename(icon), bundle_identifier,
-                      bundle_displayname, bundle_name, bundle_version, short_version_string, copyright_str,
+                      bundle_displayname, bundle_name,bundle_version,short_version_string,copyright_str,
                       main_class_name, jvm_arguments, jvm_options, jdk_xml, unique_signature, retina_screen, executable)
     copy_base_files(app_full_path, icon, jar_file, jdk, jdk_isfile, executable, executable_file)
 
@@ -527,53 +516,26 @@ def make_app(jar_file, output='.', icon=None, bundle_identifier=None, bundle_dis
 
     print("\n{} packaged to {}.".format(jar_file, os.path.abspath(app_full_path)))
 
-
 def parse_input():
     parser = OptionParser()
     parser.add_option('-n', '--name', help='Package/Bundle name.', dest='bundle_name', type='string', default=None)
-    parser.add_option('-d', '--display-name', help='Package/Bundle display name.', dest='bundle_displayname',
-                      type='string', default=None)
-    parser.add_option('-i', '--icon', help='Icon (in .icns format). (Default: None)', dest='icon', type='string',
-                      default=None)
-    parser.add_option('-b', '--bundle-identifier',
-                      help='Package/Bundle identifier (e.g. com.example.test) (Default is application name prefix by {}.'.format(
-                          DEFAULT_BUNDLE_IDENTIFIER_PREFIX), dest='bundle_identifier', type='string', default=None)
-    parser.add_option('-v', '--version',
-                      help='Package/Bundle version (e.g. 1.0.0) (Default: {}).'.format(DEFAULT_VERSION),
-                      dest='bundle_version', type='string', default=DEFAULT_VERSION)
-    parser.add_option('-s', '--short-version',
-                      help='Package/Bundle short version (see Apple\'s documentation on CFBundleShortVersionString) (Default: {}).'.format(
-                          DEFAULT_VERSION), dest='short_version_string', type='string', default=DEFAULT_VERSION)
-    parser.add_option('-c', '--copyright',
-                      help='Package/Bundle copyright string (e.g. (c) 2015 Awesome Person) (Default: empty)',
-                      dest='copyright_str', type='string', default=None)
-    parser.add_option('-u', '--unique-signature',
-                      help='4 Byte unique signature of your application (Default: {})'.format(DEFAULT_SIGNATURE),
-                      dest='signature', type='string', default=DEFAULT_SIGNATURE)
-    parser.add_option('-m', '--main-class', help='Jar main class. Blank for auto-detection (usually right).',
-                      dest='main_class_name', type='string', default=None)
-    parser.add_option('-r', '--runtime',
-                      help='JRE/JDK runtime to bundle. Can be a folder or a zip file. If none is given, the default on the system is used (default: None)',
-                      dest='jdk', type='string', default=None)
-    parser.add_option('-j', '--jvm-options',
-                      help='Extra JVM options. Place one by one, separated by spaces, inside single quotes (e.g. -o \'-Xmx1024M -Xms256M\'). (Default: None)',
-                      dest='jvm_options', type='string', default=None)
-    parser.add_option('-a', '--no-append-app-to-name', help='Do not try to append .app to the output file by default.',
-                      dest='auto_append_name', action='store_false')
-    parser.add_option('-l', '--low-res-mode',
-                      help='Do not try to report retina-screen capabilities (use low resolution mode; by default high resolution mode is used).',
-                      dest='retina_screen', action='store_false')
-    parser.add_option('-o', '--use-osx-menubar', help='Use OSX menu bar instead of Java menu bar (Default: False).',
-                      dest='use_screen_menu_bar', action='store_true')
-    parser.add_option('-x', '--executable-file',
-                      help='Internal executable to launch. By default, JavaAppLauncher provided by jar2app is used.',
-                      dest='executable_file', type='string', default=None)
-    parser.add_option('-e', '--executable-name',
-                      help='Name of the internal executable to launch (Default: %s).' % DEFAULT_EXECUTABLE_NAME,
+    parser.add_option('-d', '--display-name', help='Package/Bundle display name.', dest='bundle_displayname', type='string',default=None)
+    parser.add_option('-i', '--icon',help='Icon (in .icns format). (Default: None)', dest='icon', type='string', default=None)
+    parser.add_option('-b', '--bundle-identifier', help='Package/Bundle identifier (e.g. com.example.test) (Default is application name prefix by {}.'.format(DEFAULT_BUNDLE_IDENTIFIER_PREFIX), dest='bundle_identifier',type='string', default=None)
+    parser.add_option('-v', '--version', help='Package/Bundle version (e.g. 1.0.0) (Default: {}).'.format(DEFAULT_VERSION),dest='bundle_version', type='string', default=DEFAULT_VERSION)
+    parser.add_option('-s', '--short-version', help='Package/Bundle short version (see Apple\'s documentation on CFBundleShortVersionString) (Default: {}).'.format(DEFAULT_VERSION), dest='short_version_string',type='string', default=DEFAULT_VERSION)
+    parser.add_option('-c', '--copyright',help='Package/Bundle copyright string (e.g. (c) 2015 Awesome Person) (Default: empty)',dest='copyright_str', type='string', default=None)
+    parser.add_option('-u', '--unique-signature', help='4 Byte unique signature of your application (Default: {})'.format(DEFAULT_SIGNATURE),dest='signature', type='string', default=DEFAULT_SIGNATURE)
+    parser.add_option('-m', '--main-class', help='Jar main class. Blank for auto-detection (usually right).',dest='main_class_name', type='string', default=None)
+    parser.add_option('-r', '--runtime', help='JRE/JDK runtime to bundle. Can be a folder or a zip file. If none is given, the default on the system is used (default: None)',dest='jdk', type='string', default=None)
+    parser.add_option('-j', '--jvm-options',help='Extra JVM options. Place one by one, separated by spaces, inside single quotes (e.g. -o \'-Xmx1024M -Xms256M\'). (Default: None)',dest='jvm_options', type='string', default=None)
+    parser.add_option('-a', '--no-append-app-to-name', help='Do not try to append .app to the output file by default.', dest='auto_append_name', action='store_false')
+    parser.add_option('-l', '--low-res-mode', help='Do not try to report retina-screen capabilities (use low resolution mode; by default high resolution mode is used).',dest='retina_screen', action='store_false')
+    parser.add_option('-o', '--use-osx-menubar', help='Use OSX menu bar instead of Java menu bar (Default: False).', dest='use_screen_menu_bar', action='store_true')
+    parser.add_option('-x', '--executable-file', help='Internal executable to launch. By default, JavaAppLauncher provided by jar2app is used.', dest='executable_file', type='string', default=None)
+    parser.add_option('-e', '--executable-name', help='Name of the internal executable to launch (Default: %s).' % DEFAULT_EXECUTABLE_NAME,
                       dest='executable', default='JavaAppLauncher')
-    parser.add_option('-w', '--working-directory',
-                      help='Set current working directory (user.dir) on launch (Default: $APP_ROOT/Contents).',
-                      dest='working_directory', type='string', default='$APP_ROOT/Contents')
+    parser.add_option('-w','--working-directory', help='Set current working directory (user.dir) on launch (Default: $APP_ROOT/Contents).', dest='working_directory', type='string', default='$APP_ROOT/Contents')
     parser.add_option('-f', '--additional-jars',
                       help='Additional libraries to be added along with the primary JAR. Semicolon delimited libraries with optional comma delimiter to specify the destination directory, otherwise default to Contents/Java/ (e.g. -f=dependency.jar;dep2.jar,Contents/Java/libs/',
                       dest='libraries', type='string', default=None)
@@ -592,9 +554,7 @@ def parse_input():
         input_file = args[0]
         output = None
     else:
-        parser.error(
-            'An input file is needed. Optionally, you can also provide an output file or directory. E.g.\n{} in.jar\n{} in.jar out.app\n{} in.jar out/'.format(
-                sys.argv[0], sys.argv[0], sys.argv[0]))
+        parser.error('An input file is needed. Optionally, you can also provide an output file or directory. E.g.\n{} in.jar\n{} in.jar out.app\n{} in.jar out/'.format(sys.argv[0], sys.argv[0], sys.argv[0]) )
 
     if options.auto_append_name == None:
         options.auto_append_name = True
@@ -610,11 +570,9 @@ def parse_input():
            options.retina_screen, options.use_screen_menu_bar, options.working_directory, options.executable, \
            options.executable_file, options.libraries, options.files
 
-
 def main():
     print('jar2app %s, João Ricardo Lourenço, 2015-2017 <jorl17.8@gmail.com>.' % VERSION)
     print('Github page: https://github.com/Jorl17/jar2app/')
     make_app(*parse_input())
-
 
 main()

--- a/jar2app.py
+++ b/jar2app.py
@@ -296,7 +296,7 @@ def copy_preserve_status(src, dst):
         shutil.copy(src, dst)
 
 #------------------------------------------------------------------------------
-# Copy all files to the previously created directory. This involes copying
+# Copy all files to the previously created directory. This involves copying
 # the Localizable.strings file, the JavaAppLauncher executable and, finally,
 # the JDK/JRE and application icon if they were provided
 #------------------------------------------------------------------------------
@@ -311,6 +311,11 @@ def copy_base_files(app_full_path, icon, jar_file, jdk, jdk_isfile, executable, 
     make_executable(os.path.join(app_full_path, 'Contents', 'MacOS', executable))
     copy_preserve_status(jar_file, os.path.join(app_full_path, 'Contents', 'Java', os.path.basename(jar_file)))
     copy_jdk(app_full_path, jdk, jdk_isfile)
+
+
+def copy_additional_files_and_libraries(app_full_path, libs:str, files):
+    libs_and_dirs = dict(libdir.split(';') for libdir in libs)
+    copy_preserve_status(libs, os.path.join(app_full_path))
 
 #------------------------------------------------------------------------------
 # Determine the destination Appname (and full path) taking into account the
@@ -486,7 +491,12 @@ def parse_input():
     parser.add_option('-x', '--executable-file', help='Internal executable to launch. By default, JavaAppLauncher provided by jar2app is used.', dest='executable_file', type='string', default=None)
     parser.add_option('-e', '--executable-name', help='Name of the internal executable to launch (Default: %s).' % DEFAULT_EXECUTABLE_NAME,
                       dest='executable', default='JavaAppLauncher')
-    parser.add_option('-w','--working-directory', help='Set current working directory (user.dir) on launch (Default: $APP_ROOT/Contents).', dest='working_directory', type='string', default='$APP_ROOT/Contents')
+    parser.add_option('-w', '--working-directory', help='Set current working directory (user.dir) on launch (Default: $APP_ROOT/Contents).', dest='working_directory', type='string', default='$APP_ROOT/Contents')
+    parser.add_option('-f', '-additional-jars', help='Additional libraries to be added along with the primary JAR. Semicolon delimited libraries with optional comma delimiter to specify the destination directory, otherwise default to Contents/Java (e.g. -f \'dependency.jar;dep2.jar,Contents/Java/libs/\'',
+                      dest='libraries',  type='string', default=None)
+    parser.add_option('-g', '--additional-files', help='Additional files to be added to the app. Semicolon delimited files with mandatory comma delimited directory (e.g. --additional-files \'db1.db,Contents/Java/databases;db2.db,Contents/Java/databases\'',
+                      dest='files', type='string', default=None)
+
 
     (options, args) = parser.parse_args()
 
@@ -513,7 +523,7 @@ def parse_input():
            options.bundle_version, options.short_version_string, options.copyright_str, options.main_class_name,\
            jvm_arguments, options.jvm_options, options.jdk, options.signature, options.auto_append_name,\
            options.retina_screen, options.use_screen_menu_bar, options.working_directory, options.executable,\
-           options.executable_file
+           options.executable_file, options.libraries, options.files
 
 def main():
     print('jar2app %s, João Ricardo Lourenço, 2015-2017 <jorl17.8@gmail.com>.' % VERSION)

--- a/jar2app.py
+++ b/jar2app.py
@@ -38,19 +38,17 @@ is_python2 = sys.version_info[0] == 2
 if is_python2:
     FileExistsError = OSError
 
-
-
-#------------------------------------------------------------------------------
+# ------------------------------------------------------------------------------
 # Defaults
-#------------------------------------------------------------------------------
-DEFAULT_VERSION='1.0.1'
-DEFAULT_BUNDLE_IDENTIFIER_PREFIX='com.jar2app.example.'
-DEFAULT_SIGNATURE='????'
-DEFAULT_EXECUTABLE_NAME='JavaAppLauncher'
+# ------------------------------------------------------------------------------
+DEFAULT_VERSION = '1.0.1'
+DEFAULT_BUNDLE_IDENTIFIER_PREFIX = 'com.jar2app.example.'
+DEFAULT_SIGNATURE = '????'
+DEFAULT_EXECUTABLE_NAME = 'JavaAppLauncher'
 
-#------------------------------------------------------------------------------
+# ------------------------------------------------------------------------------
 # The info.plist file with placeholders
-#------------------------------------------------------------------------------
+# ------------------------------------------------------------------------------
 info_plist = """<?xml version="1.0" ?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
@@ -119,9 +117,9 @@ retina_support_string = """<key>NSPrincipalClass</key>
     <string>True</string>"""
 
 
-#------------------------------------------------------------------------------
+# ------------------------------------------------------------------------------
 # Create a directory and ignore the "File already exists" error
-#------------------------------------------------------------------------------
+# ------------------------------------------------------------------------------
 def mkdir_ignore_exists(p):
     try:
         os.mkdir(p)
@@ -129,25 +127,28 @@ def mkdir_ignore_exists(p):
     except FileExistsError:
         return False
 
-#------------------------------------------------------------------------------
+
+# ------------------------------------------------------------------------------
 # Make a file executable
-#------------------------------------------------------------------------------
+# ------------------------------------------------------------------------------
 def make_executable(path):
     mode = os.stat(path).st_mode
     mode |= (mode & 0o444) >> 2
     os.chmod(path, mode)
 
-#------------------------------------------------------------------------------
+
+# ------------------------------------------------------------------------------
 # Just strip the extension from a name
-#------------------------------------------------------------------------------
+# ------------------------------------------------------------------------------
 def strip_extension_from_name(name):
     return os.path.splitext(name)[0]
 
-#------------------------------------------------------------------------------
+
+# ------------------------------------------------------------------------------
 # Determine the main class in a JAR file. This basically involves searching
 # through the JAR (it's just a zip file), locating the MANIFEST.MF file,
 # decompressing it and then finding the main-class line.
-#------------------------------------------------------------------------------
+# ------------------------------------------------------------------------------
 def find_jar_mainclass(jar_file):
     f = ZipFile(jar_file, 'r')
     for file in f.infolist():
@@ -159,7 +160,8 @@ def find_jar_mainclass(jar_file):
                 if line.strip().lower().startswith('main-class'):
                     return line.split(':')[1].strip()
 
-#------------------------------------------------------------------------------
+
+# ------------------------------------------------------------------------------
 # Build the main directory structure of the .App. It should look like
 # <appname>.App/
 #              Contents/
@@ -167,9 +169,9 @@ def find_jar_mainclass(jar_file):
 #                       MacOS/
 #                       Resources/
 #                                 en.lproj/
-#------------------------------------------------------------------------------
+# ------------------------------------------------------------------------------
 def build_directory_structure(app_full_path):
-    mkdir_ignore_exists(os.path.dirname(app_full_path)) #Base output directory where the app is placed. Create it.
+    mkdir_ignore_exists(os.path.dirname(app_full_path))  # Base output directory where the app is placed. Create it.
     mkdir_ignore_exists(app_full_path)
     mkdir_ignore_exists(os.path.join(app_full_path, 'Contents'))
     mkdir_ignore_exists(os.path.join(app_full_path, 'Contents', 'Java'))
@@ -178,36 +180,38 @@ def build_directory_structure(app_full_path):
     mkdir_ignore_exists(os.path.join(app_full_path, 'Contents', 'Resources'))
     mkdir_ignore_exists(os.path.join(app_full_path, 'Contents', 'Resources', 'en.lproj'))
 
-#------------------------------------------------------------------------------
+
+# ------------------------------------------------------------------------------
 # Write the plist file in the desired output folder. Note that these arguments
 # are passed directly to the info_plist string, so some of them (jdk,
 # jvm_arguments...) should have a bit of XML.
 #
 # The destination folder is typically <appname>.App/Contents
-#------------------------------------------------------------------------------
-def create_plist_file(destination_folder, icon, bundle_identifier, bundle_displayname, bundle_name,bundle_version,
-                      short_version_string,copyright_str, main_class_name, jvm_arguments, jvm_options, jdk,
+# ------------------------------------------------------------------------------
+def create_plist_file(destination_folder, icon, bundle_identifier, bundle_displayname, bundle_name, bundle_version,
+                      short_version_string, copyright_str, main_class_name, jvm_arguments, jvm_options, jdk,
                       unique_signature, retina_support, executable):
-    filled_info_plist=info_plist.format(icon=icon,
-                                        bundle_identifier=bundle_identifier,
-                                        bundle_displayname=bundle_displayname,
-                                        bundle_name=bundle_name,
-                                        bundle_version=bundle_version,
-                                        short_version_string=short_version_string,
-                                        copyright=copyright_str,
-                                        main_class_name=main_class_name,
-                                        jvm_arguments=jvm_arguments,
-                                        jvm_options=jvm_options,
-                                        jdk=jdk,
-                                        unique_signature=unique_signature,
-                                        retina_support=retina_support,
-                                        executable=executable,
-                                        version=VERSION)
+    filled_info_plist = info_plist.format(icon=icon,
+                                          bundle_identifier=bundle_identifier,
+                                          bundle_displayname=bundle_displayname,
+                                          bundle_name=bundle_name,
+                                          bundle_version=bundle_version,
+                                          short_version_string=short_version_string,
+                                          copyright=copyright_str,
+                                          main_class_name=main_class_name,
+                                          jvm_arguments=jvm_arguments,
+                                          jvm_options=jvm_options,
+                                          jdk=jdk,
+                                          unique_signature=unique_signature,
+                                          retina_support=retina_support,
+                                          executable=executable,
+                                          version=VERSION)
 
     with open(os.path.join(destination_folder, 'Info.plist'), 'w') as f:
         f.write(filled_info_plist)
 
-#------------------------------------------------------------------------------
+
+# ------------------------------------------------------------------------------
 # Convert a sequence of strings, separated by spaces, into a sequence of
 # <string></string> strings.
 # E.g., "a b c" becomes "<string>a</string>b<string></string><string>c</string>
@@ -215,23 +219,24 @@ def create_plist_file(destination_folder, icon, bundle_identifier, bundle_displa
 # This is to be used for the JVMArguments and JVMOptions in the plist.xml file.
 # Also note that there is some whitespace added. This is to comply with the
 # indent of the xml file.
-#------------------------------------------------------------------------------
+# ------------------------------------------------------------------------------
 def string_to_plist_xmlarray_values(s):
     if not s:
         return ''
-    return  '        <string>' + '</string>\n        <string>'.join( [i.strip() for i in shlex.split(s) ] ) + '</string>'
+    return '        <string>' + '</string>\n        <string>'.join([i.strip() for i in shlex.split(s)]) + '</string>'
 
-#------------------------------------------------------------------------------
+
+# ------------------------------------------------------------------------------
 # Check if JDK/JRE is valid. It can be a zip file or it can be a directory.
 # Returns:
 #   * The xml string to use
 #   * The JDK/JRE folder name (not its full path; e.g. for zip files, it strips
 #     the zip extension)
 #   * Whether the JDK/JRE is a file or a directory
-#------------------------------------------------------------------------------
+# ------------------------------------------------------------------------------
 def determine_jdk(jdk):
     if not jdk:
-        return '','',True
+        return '', '', True
     isfile = os.path.isfile(jdk)
     if isfile:
         if not jdk.lower().endswith('.zip'):
@@ -239,9 +244,10 @@ def determine_jdk(jdk):
         jdk = strip_extension_from_name(os.path.basename(jdk))
 
     dir, name = os.path.split(jdk)
-    return '<key>JVMRuntime</key>\n<string>' + name + '</string>',jdk,isfile
+    return '<key>JVMRuntime</key>\n<string>' + name + '</string>', jdk, isfile
 
-#------------------------------------------------------------------------------
+
+# ------------------------------------------------------------------------------
 # Copy a JDK to the bundled .app. The app_full_path should be the root of
 # the app (e.g. Test.app/). JDK should be the path to the JDK/JRE and
 # jdk_isfile comes from determine_jdk and indicates if the this JDK is a zip
@@ -256,7 +262,7 @@ def determine_jdk(jdk):
 #
 # This JDK should be in the format expected by AppBundler (check if the first
 # directory is just a Contents folder)
-#------------------------------------------------------------------------------
+# ------------------------------------------------------------------------------
 def copy_jdk(app_full_path, jdk, jdk_isfile):
     if jdk:
         if jdk_isfile:
@@ -269,7 +275,7 @@ def copy_jdk(app_full_path, jdk, jdk_isfile):
                 os.rmdir(destination_path)
                 shutil.copytree(jdk_dir, destination_path)
             except FileExistsError as e:
-                raise # FIXME
+                raise  # FIXME
             try:
                 base_path = os.path.join(app_full_path, 'Contents', 'PlugIns')
                 dir = os.listdir(base_path)[0]
@@ -278,10 +284,10 @@ def copy_jdk(app_full_path, jdk, jdk_isfile):
                 os.rename(os.path.join(base_path, dir), final_dir)
                 shutil.rmtree(tmpdir)
             except:
-                raise #FIXME
+                raise  # FIXME
         else:
             destination = os.path.join(app_full_path, 'Contents', 'PlugIns', os.path.basename(jdk))
-            shutil.rmtree(destination, ignore_errors=True) # Delete old folder (if it exists)
+            shutil.rmtree(destination, ignore_errors=True)  # Delete old folder (if it exists)
             shutil.copytree(jdk, destination, symlinks=True)
 
 
@@ -295,44 +301,68 @@ def copy_preserve_status(src, dst):
     except OSError:
         shutil.copy(src, dst)
 
-#------------------------------------------------------------------------------
+
+# ------------------------------------------------------------------------------
 # Copy all files to the previously created directory. This involves copying
 # the Localizable.strings file, the JavaAppLauncher executable and, finally,
 # the JDK/JRE and application icon if they were provided
-#------------------------------------------------------------------------------
+# ------------------------------------------------------------------------------
 def copy_base_files(app_full_path, icon, jar_file, jdk, jdk_isfile, executable, executable_file):
     if icon:
-        copy_preserve_status(icon,os.path.join(app_full_path, 'Contents', 'Resources'))
-    copy_preserve_status(os.path.join(os.path.dirname(sys.argv[0]), 'jar2app_basefiles', 'Localizable.strings'), os.path.join(app_full_path, 'Contents', 'Resources', 'en.lproj', 'Localizable.strings'))
+        copy_preserve_status(icon, os.path.join(app_full_path, 'Contents', 'Resources'))
+    copy_preserve_status(os.path.join(os.path.dirname(sys.argv[0]), 'jar2app_basefiles', 'Localizable.strings'),
+                         os.path.join(app_full_path, 'Contents', 'Resources', 'en.lproj', 'Localizable.strings'))
     if executable_file:
         copy_preserve_status(executable_file, os.path.join(app_full_path, 'Contents', 'MacOS', executable))
     else:
-        copy_preserve_status(os.path.join(os.path.dirname(sys.argv[0]), 'jar2app_basefiles', 'JavaAppLauncher'), os.path.join(app_full_path, 'Contents', 'MacOS', executable))
+        copy_preserve_status(os.path.join(os.path.dirname(sys.argv[0]), 'jar2app_basefiles', 'JavaAppLauncher'),
+                             os.path.join(app_full_path, 'Contents', 'MacOS', executable))
     make_executable(os.path.join(app_full_path, 'Contents', 'MacOS', executable))
     copy_preserve_status(jar_file, os.path.join(app_full_path, 'Contents', 'Java', os.path.basename(jar_file)))
     copy_jdk(app_full_path, jdk, jdk_isfile)
 
-#------------------------------------------------------------------------------
+
+# ------------------------------------------------------------------------------
 # Create new directories if necessary and copy the libraries/files to the
 # new directories or the default directory if no path is given
-#------------------------------------------------------------------------------
+# ------------------------------------------------------------------------------
 def copy_additional_files_and_libraries(app_full_path, libs_or_files, default_path):
-    # create mapping to libs/files to respective directories
+    # create mapping of libs/files to respective directories
     libs_or_files_and_dirs = (dict([lib_dir.split(',')]) if len(lib_dir.split(',')) > 1 else {lib_dir: ""} for lib_dir in libs_or_files.split(';'))
 
     # create directories for libraries/files using the given structure
     # If directory structure is empty, use the given default
     # Otherwise parse given directory to extract subdirectory elements, split on '/', and strip empty strings
     for lib_file_dir in libs_or_files_and_dirs:
-        if list(lib_file_dir.values())[0] == '':
-            # default to Contents directory
-            copy_preserve_status(list(lib_file_dir.keys())[0], os.path.join(app_full_path, *default_path))
-        else:
-            final_dir_list = list(dir_element for dir_element in (list(subdir for subdir in lib_file_dir.values())[0].split("/")) if dir_element)
-            mkdir_ignore_exists(os.path.join(app_full_path, *final_dir_list))
-            copy_preserve_status(list(lib_file_dir.keys())[0], os.path.join(app_full_path, *final_dir_list))
+        lib_or_file = list(lib_file_dir.keys())[0]
+        path = list(lib_file_dir.values())[0]
 
-#------------------------------------------------------------------------------
+        if not os.path.exists(lib_or_file):
+            raise Exception("Additional libraries or files not found")
+
+        # Directory not given
+        if path == '':
+            # handle entire folders
+            if os.path.isdir(lib_or_file):
+                for item in os.listdir(lib_or_file):
+                    copy_preserve_status(os.path.join(lib_or_file, item), os.path.join(app_full_path, *default_path))
+            else:
+                # handle single JAR/file
+                copy_preserve_status(lib_or_file, os.path.join(app_full_path, *default_path))
+        else:
+            # Directory given
+            # handle entire folders
+            if os.path.isdir(lib_or_file):
+                for item in os.listdir(lib_or_file):
+                    final_dir_list = list(dir_element for dir_element in (path.split("/")) if dir_element)
+                    mkdir_ignore_exists(os.path.join(app_full_path, *final_dir_list))
+                    copy_preserve_status(os.path.join(lib_or_file, item), os.path.join(app_full_path, *final_dir_list))
+            else:
+                # handle single JAR/file
+                copy_preserve_status(lib_or_file, os.path.join(app_full_path, *default_path))
+
+
+# ------------------------------------------------------------------------------
 # Determine the destination Appname (and full path) taking into account the
 # parameters. Note that:
 # 1. If output is provided and it is a destination file, its name is used as
@@ -343,13 +373,13 @@ def copy_additional_files_and_libraries(app_full_path, libs_or_files, default_pa
 # 4. Prefer the bundle displayname
 # 5. Prefer the jar name (without extension, of course)
 # We also assume that by default the output should go to the current directory.
-#------------------------------------------------------------------------------
+# ------------------------------------------------------------------------------
 def determine_app_name(jar_name, output, bundle_displayname, bundle_name, auto_append_app):
     if output:
-        dir,name = os.path.split(output)
-        if not dir: #All that was given was a filename
+        dir, name = os.path.split(output)
+        if not dir:  # All that was given was a filename
             dir = '.'
-    else: #Assume default directory
+    else:  # Assume default directory
         dir = '.'
         name = ''
 
@@ -359,25 +389,26 @@ def determine_app_name(jar_name, output, bundle_displayname, bundle_name, auto_a
         # 2. the bundle_displayname, if it was provided
         # 3. The jar name
         if bundle_name:
-            return os.path.join(dir,bundle_name + '.app')
+            return os.path.join(dir, bundle_name + '.app')
         elif bundle_displayname:
-            return os.path.join(dir,bundle_displayname + '.app')
+            return os.path.join(dir, bundle_displayname + '.app')
         elif jar_name:
-            return os.path.join(dir,strip_extension_from_name(jar_name) + '.app')
+            return os.path.join(dir, strip_extension_from_name(jar_name) + '.app')
     else:
         # Ensure the name ends with .app, unless we were told not to do so
         if auto_append_app:
             if name.lower().endswith('.app'):
-                return os.path.join(dir,name)
+                return os.path.join(dir, name)
             else:
-                return os.path.join(dir,name + '.app')
+                return os.path.join(dir, name + '.app')
         else:
-            return os.path.join(dir,name)
+            return os.path.join(dir, name)
 
-#------------------------------------------------------------------------------
+
+# ------------------------------------------------------------------------------
 # Print summary info on the fields used, if they are used. Used when the
 # process is done
-#------------------------------------------------------------------------------
+# ------------------------------------------------------------------------------
 def print_final_file_info(icon, bundle_identifier, bundle_displayname, bundle_name, short_version_string,
                           unique_signature, bundle_version, copyright_str, orig_jvm_options, main_class_name,
                           jdk, retina_support, use_screen_menu_bar, working_directory, executable):
@@ -406,12 +437,13 @@ def print_final_file_info(icon, bundle_identifier, bundle_displayname, bundle_na
     print_field_if_not_null('Executable Name (CFBundleExecutable)', executable)
     print_field_if_not_null('JAR Working directory', working_directory)
 
-#------------------------------------------------------------------------------
+
+# ------------------------------------------------------------------------------
 # This is the main application logic. It receives the arguments straight from
 # the user, gives appropriate defaults, builds the directory structure,
 # copies files (packing the JDK/JRE) and creates the plist file. In the end,
 # if all went well, it displays summary info.
-#------------------------------------------------------------------------------
+# ------------------------------------------------------------------------------
 def make_app(jar_file, output='.', icon=None, bundle_identifier=None, bundle_displayname=None, bundle_name=None,
              bundle_version=None, short_version_string=None, copyright_str=None, main_class_name=None,
              jvm_arguments=None, jvm_options=None, jdk=None, unique_signature=None, auto_append_app=True,
@@ -420,12 +452,12 @@ def make_app(jar_file, output='.', icon=None, bundle_identifier=None, bundle_dis
     def default_value(d, default):
         return d if d else default
 
-    orig_jvm_options  = jvm_options
+    orig_jvm_options = jvm_options
     if not jvm_options: jvm_options = ''
-    jar_name          = os.path.basename(jar_file)
-    app_full_path     = determine_app_name(jar_name, output, bundle_displayname, bundle_name, auto_append_app)
-    app_name          = strip_extension_from_name(os.path.basename(app_full_path))
-    icon              = default_value(icon, '')
+    jar_name = os.path.basename(jar_file)
+    app_full_path = determine_app_name(jar_name, output, bundle_displayname, bundle_name, auto_append_app)
+    app_name = strip_extension_from_name(os.path.basename(app_full_path))
+    icon = default_value(icon, '')
     bundle_identifier = default_value(bundle_identifier, DEFAULT_BUNDLE_IDENTIFIER_PREFIX + app_name)
 
     if jdk:
@@ -449,7 +481,7 @@ def make_app(jar_file, output='.', icon=None, bundle_identifier=None, bundle_dis
         else:
             bundle_displayname = app_name
 
-	# Set the app name in the macOS menu bar (About and Quit menu items)
+    # Set the app name in the macOS menu bar (About and Quit menu items)
     jvm_options += ' -Xdock:name="%s"' % bundle_displayname
 
     # When we get here, we always have a displayname. So if there's no bundlename, go with that. It may itself have
@@ -457,16 +489,16 @@ def make_app(jar_file, output='.', icon=None, bundle_identifier=None, bundle_dis
     bundle_name = default_value(bundle_name, bundle_displayname)
 
     if not bundle_version:
-            bundle_version = short_version_string if short_version_string else DEFAULT_VERSION
+        bundle_version = short_version_string if short_version_string else DEFAULT_VERSION
 
     # When we get here, we always have bundle_version, even if it is the default
-    short_version_string        = default_value(short_version_string, bundle_version)
-    copyright_str               = default_value(copyright_str, '')
-    main_class_name             = default_value(main_class_name, find_jar_mainclass(jar_file))
-    unique_signature            = default_value(unique_signature, '????')
-    jvm_arguments               = string_to_plist_xmlarray_values(jvm_arguments)
-    jvm_options                 = string_to_plist_xmlarray_values(jvm_options)
-    jdk_xml,jdk_name,jdk_isfile = determine_jdk(jdk)
+    short_version_string = default_value(short_version_string, bundle_version)
+    copyright_str = default_value(copyright_str, '')
+    main_class_name = default_value(main_class_name, find_jar_mainclass(jar_file))
+    unique_signature = default_value(unique_signature, '????')
+    jvm_arguments = string_to_plist_xmlarray_values(jvm_arguments)
+    jvm_options = string_to_plist_xmlarray_values(jvm_options)
+    jdk_xml, jdk_name, jdk_isfile = determine_jdk(jdk)
 
     if retina_screen:
         retina_screen = retina_support_string
@@ -477,15 +509,17 @@ def make_app(jar_file, output='.', icon=None, bundle_identifier=None, bundle_dis
 
     build_directory_structure(app_full_path)
     create_plist_file(os.path.join(app_full_path, 'Contents'), os.path.basename(icon), bundle_identifier,
-                      bundle_displayname, bundle_name,bundle_version,short_version_string,copyright_str,
+                      bundle_displayname, bundle_name, bundle_version, short_version_string, copyright_str,
                       main_class_name, jvm_arguments, jvm_options, jdk_xml, unique_signature, retina_screen, executable)
     copy_base_files(app_full_path, icon, jar_file, jdk, jdk_isfile, executable, executable_file)
 
     # Copy additional libraries
-    copy_additional_files_and_libraries(app_full_path, libraries, ['Contents', 'Java'])
+    if libraries is not None:
+        copy_additional_files_and_libraries(app_full_path, libraries, ['Contents', 'Java'])
 
     # Copy additional files
-    copy_additional_files_and_libraries(app_full_path, files, ['Contents'])
+    if files is not None:
+        copy_additional_files_and_libraries(app_full_path, files, ['Contents'])
 
     print_final_file_info(icon, bundle_identifier, bundle_displayname, bundle_name, short_version_string,
                           unique_signature, bundle_version, copyright_str, orig_jvm_options, main_class_name,
@@ -493,31 +527,59 @@ def make_app(jar_file, output='.', icon=None, bundle_identifier=None, bundle_dis
 
     print("\n{} packaged to {}.".format(jar_file, os.path.abspath(app_full_path)))
 
+
 def parse_input():
     parser = OptionParser()
     parser.add_option('-n', '--name', help='Package/Bundle name.', dest='bundle_name', type='string', default=None)
-    parser.add_option('-d', '--display-name', help='Package/Bundle display name.', dest='bundle_displayname', type='string',default=None)
-    parser.add_option('-i', '--icon',help='Icon (in .icns format). (Default: None)', dest='icon', type='string', default=None)
-    parser.add_option('-b', '--bundle-identifier', help='Package/Bundle identifier (e.g. com.example.test) (Default is application name prefix by {}.'.format(DEFAULT_BUNDLE_IDENTIFIER_PREFIX), dest='bundle_identifier',type='string', default=None)
-    parser.add_option('-v', '--version', help='Package/Bundle version (e.g. 1.0.0) (Default: {}).'.format(DEFAULT_VERSION),dest='bundle_version', type='string', default=DEFAULT_VERSION)
-    parser.add_option('-s', '--short-version', help='Package/Bundle short version (see Apple\'s documentation on CFBundleShortVersionString) (Default: {}).'.format(DEFAULT_VERSION), dest='short_version_string',type='string', default=DEFAULT_VERSION)
-    parser.add_option('-c', '--copyright',help='Package/Bundle copyright string (e.g. (c) 2015 Awesome Person) (Default: empty)',dest='copyright_str', type='string', default=None)
-    parser.add_option('-u', '--unique-signature', help='4 Byte unique signature of your application (Default: {})'.format(DEFAULT_SIGNATURE),dest='signature', type='string', default=DEFAULT_SIGNATURE)
-    parser.add_option('-m', '--main-class', help='Jar main class. Blank for auto-detection (usually right).',dest='main_class_name', type='string', default=None)
-    parser.add_option('-r', '--runtime', help='JRE/JDK runtime to bundle. Can be a folder or a zip file. If none is given, the default on the system is used (default: None)',dest='jdk', type='string', default=None)
-    parser.add_option('-j', '--jvm-options',help='Extra JVM options. Place one by one, separated by spaces, inside single quotes (e.g. -o \'-Xmx1024M -Xms256M\'). (Default: None)',dest='jvm_options', type='string', default=None)
-    parser.add_option('-a', '--no-append-app-to-name', help='Do not try to append .app to the output file by default.', dest='auto_append_name', action='store_false')
-    parser.add_option('-l', '--low-res-mode', help='Do not try to report retina-screen capabilities (use low resolution mode; by default high resolution mode is used).',dest='retina_screen', action='store_false')
-    parser.add_option('-o', '--use-osx-menubar', help='Use OSX menu bar instead of Java menu bar (Default: False).', dest='use_screen_menu_bar', action='store_true')
-    parser.add_option('-x', '--executable-file', help='Internal executable to launch. By default, JavaAppLauncher provided by jar2app is used.', dest='executable_file', type='string', default=None)
-    parser.add_option('-e', '--executable-name', help='Name of the internal executable to launch (Default: %s).' % DEFAULT_EXECUTABLE_NAME,
+    parser.add_option('-d', '--display-name', help='Package/Bundle display name.', dest='bundle_displayname',
+                      type='string', default=None)
+    parser.add_option('-i', '--icon', help='Icon (in .icns format). (Default: None)', dest='icon', type='string',
+                      default=None)
+    parser.add_option('-b', '--bundle-identifier',
+                      help='Package/Bundle identifier (e.g. com.example.test) (Default is application name prefix by {}.'.format(
+                          DEFAULT_BUNDLE_IDENTIFIER_PREFIX), dest='bundle_identifier', type='string', default=None)
+    parser.add_option('-v', '--version',
+                      help='Package/Bundle version (e.g. 1.0.0) (Default: {}).'.format(DEFAULT_VERSION),
+                      dest='bundle_version', type='string', default=DEFAULT_VERSION)
+    parser.add_option('-s', '--short-version',
+                      help='Package/Bundle short version (see Apple\'s documentation on CFBundleShortVersionString) (Default: {}).'.format(
+                          DEFAULT_VERSION), dest='short_version_string', type='string', default=DEFAULT_VERSION)
+    parser.add_option('-c', '--copyright',
+                      help='Package/Bundle copyright string (e.g. (c) 2015 Awesome Person) (Default: empty)',
+                      dest='copyright_str', type='string', default=None)
+    parser.add_option('-u', '--unique-signature',
+                      help='4 Byte unique signature of your application (Default: {})'.format(DEFAULT_SIGNATURE),
+                      dest='signature', type='string', default=DEFAULT_SIGNATURE)
+    parser.add_option('-m', '--main-class', help='Jar main class. Blank for auto-detection (usually right).',
+                      dest='main_class_name', type='string', default=None)
+    parser.add_option('-r', '--runtime',
+                      help='JRE/JDK runtime to bundle. Can be a folder or a zip file. If none is given, the default on the system is used (default: None)',
+                      dest='jdk', type='string', default=None)
+    parser.add_option('-j', '--jvm-options',
+                      help='Extra JVM options. Place one by one, separated by spaces, inside single quotes (e.g. -o \'-Xmx1024M -Xms256M\'). (Default: None)',
+                      dest='jvm_options', type='string', default=None)
+    parser.add_option('-a', '--no-append-app-to-name', help='Do not try to append .app to the output file by default.',
+                      dest='auto_append_name', action='store_false')
+    parser.add_option('-l', '--low-res-mode',
+                      help='Do not try to report retina-screen capabilities (use low resolution mode; by default high resolution mode is used).',
+                      dest='retina_screen', action='store_false')
+    parser.add_option('-o', '--use-osx-menubar', help='Use OSX menu bar instead of Java menu bar (Default: False).',
+                      dest='use_screen_menu_bar', action='store_true')
+    parser.add_option('-x', '--executable-file',
+                      help='Internal executable to launch. By default, JavaAppLauncher provided by jar2app is used.',
+                      dest='executable_file', type='string', default=None)
+    parser.add_option('-e', '--executable-name',
+                      help='Name of the internal executable to launch (Default: %s).' % DEFAULT_EXECUTABLE_NAME,
                       dest='executable', default='JavaAppLauncher')
-    parser.add_option('-w', '--working-directory', help='Set current working directory (user.dir) on launch (Default: $APP_ROOT/Contents).', dest='working_directory', type='string', default='$APP_ROOT/Contents')
-    parser.add_option('-f', '--additional-jars', help='Additional libraries to be added along with the primary JAR. Semicolon delimited libraries with optional comma delimiter to specify the destination directory, otherwise default to Contents/Java/ (e.g. -f \'dependency.jar;dep2.jar,Contents/Java/libs/\'',
-                      dest='libraries',  type='string', default=None)
-    parser.add_option('-g', '--additional-files', help='Additional files to be added to the app. Semicolon delimited files with optional comma delimited destination directory, otherwise default to Contents/ (e.g. --additional-files \'db1.db,Contents/Java/databases;db2.db,Contents/Java/databases\'',
+    parser.add_option('-w', '--working-directory',
+                      help='Set current working directory (user.dir) on launch (Default: $APP_ROOT/Contents).',
+                      dest='working_directory', type='string', default='$APP_ROOT/Contents')
+    parser.add_option('-f', '--additional-jars',
+                      help='Additional libraries to be added along with the primary JAR. Semicolon delimited libraries with optional comma delimiter to specify the destination directory, otherwise default to Contents/Java/ (e.g. -f=dependency.jar;dep2.jar,Contents/Java/libs/',
+                      dest='libraries', type='string', default=None)
+    parser.add_option('-g', '--additional-files',
+                      help='Additional files to be added to the app. Semicolon delimited files with optional comma delimited destination directory, otherwise default to Contents/ (e.g. --additional-files=db1.db,Contents/Java/databases;db2.db,Contents/Java/databases',
                       dest='files', type='string', default=None)
-
 
     (options, args) = parser.parse_args()
 
@@ -530,7 +592,9 @@ def parse_input():
         input_file = args[0]
         output = None
     else:
-        parser.error('An input file is needed. Optionally, you can also provide an output file or directory. E.g.\n{} in.jar\n{} in.jar out.app\n{} in.jar out/'.format(sys.argv[0], sys.argv[0], sys.argv[0]) )
+        parser.error(
+            'An input file is needed. Optionally, you can also provide an output file or directory. E.g.\n{} in.jar\n{} in.jar out.app\n{} in.jar out/'.format(
+                sys.argv[0], sys.argv[0], sys.argv[0]))
 
     if options.auto_append_name == None:
         options.auto_append_name = True
@@ -540,15 +604,17 @@ def parse_input():
 
     jvm_arguments = ''
 
-    return input_file, output, options.icon, options.bundle_identifier, options.bundle_displayname, options.bundle_name,\
-           options.bundle_version, options.short_version_string, options.copyright_str, options.main_class_name,\
-           jvm_arguments, options.jvm_options, options.jdk, options.signature, options.auto_append_name,\
-           options.retina_screen, options.use_screen_menu_bar, options.working_directory, options.executable,\
+    return input_file, output, options.icon, options.bundle_identifier, options.bundle_displayname, options.bundle_name, \
+           options.bundle_version, options.short_version_string, options.copyright_str, options.main_class_name, \
+           jvm_arguments, options.jvm_options, options.jdk, options.signature, options.auto_append_name, \
+           options.retina_screen, options.use_screen_menu_bar, options.working_directory, options.executable, \
            options.executable_file, options.libraries, options.files
+
 
 def main():
     print('jar2app %s, João Ricardo Lourenço, 2015-2017 <jorl17.8@gmail.com>.' % VERSION)
     print('Github page: https://github.com/Jorl17/jar2app/')
     make_app(*parse_input())
+
 
 main()


### PR DESCRIPTION
Both options use the same method call with a difference in default destination directories. They also allow the user to pass a directory of JARs or files rather than needing to pass individual items. If passing a directory of JARs/files then be sure to specify the destination directory as well or they will be dropped in the default directory.

Use cases:

- folder of jars (libraries) to default directory Contents/Java/ or given directory
- individual jars to default directory Contents/Java/ or given directory

- folder of files to default directory Contents/ or given directory
- individual files to default directory Contents/ or given directory